### PR TITLE
add empa scanning probe app

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -28,6 +28,11 @@
         "git_url": "https://github.com/edditler/mc-empa-reactions",
         "meta_url": "https://raw.githubusercontent.com/edditler/mc-empa-reactions/master/metadata.json",
         "label": "reactions"
+    },    
+    "scanning_probe": {
+        "git_url": "https://github.com/eimrek/mc-empa-scanning-probe",
+        "meta_url": "https://raw.githubusercontent.com/eimrek/mc-empa-scanning-probe/master/metadata.json",
+        "label": "Empa scanning probe"
     },
     "units": {
         "git_url": "https://github.com/materialscloud-org/mc-units",


### PR DESCRIPTION
Hi! I would like to add the Empa scanning probe app to the list. Currently there is a dependence also on the Empa surfaces app (the structure-browser).

Even though some of the other apps used dashes in the name, I picked underscore for mine, as it works better in case there is need to import the module in python.